### PR TITLE
채팅방 삭제 로직 수정 완료

### DIFF
--- a/src/main/java/com/motionmate/domain/chat/ChatMessageRepository.java
+++ b/src/main/java/com/motionmate/domain/chat/ChatMessageRepository.java
@@ -1,11 +1,20 @@
 package com.motionmate.domain.chat;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     List<ChatMessage> findByChatRoomOrderBySentAtAsc(ChatRoom chatRoom);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ChatMessage m WHERE m.chatRoom.id = :chatRoomId")
+    void deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }
 
 

--- a/src/main/java/com/motionmate/domain/chat/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/motionmate/domain/chat/ChatRoomParticipantRepository.java
@@ -1,7 +1,11 @@
 package com.motionmate.domain.chat;
 
 import com.motionmate.domain.user.User;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,5 +19,11 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
     List<ChatRoomParticipant> findByChatRoom(ChatRoom chatRoom); // 전체 멤버 조회
 
     long countByChatRoomAndConnectedTrue(ChatRoom chatRoom);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ChatRoomParticipant p WHERE p.chatRoom.id = :chatRoomId")
+    void deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+
 
 }

--- a/src/main/java/com/motionmate/service/ChatRoomService.java
+++ b/src/main/java/com/motionmate/service/ChatRoomService.java
@@ -1,9 +1,6 @@
 package com.motionmate.service;
 
-import com.motionmate.domain.chat.ChatRoom;
-import com.motionmate.domain.chat.ChatRoomParticipant;
-import com.motionmate.domain.chat.ChatRoomParticipantRepository;
-import com.motionmate.domain.chat.ChatRoomRepository;
+import com.motionmate.domain.chat.*;
 import com.motionmate.domain.user.User;
 import com.motionmate.domain.user.UserProfileRepository;
 import com.motionmate.domain.user.UserRepository;
@@ -28,6 +25,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final UserProfileRepository userProfileRepository;
     private final ChatRoomParticipantRepository chatRoomParticipantRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     // 채팅방 생성 (nickname 기반)
     @Transactional
@@ -150,7 +148,15 @@ public class ChatRoomService {
             throw new SecurityException("채팅방 생성자만 삭제할 수 있습니다.");
         }
 
+        // ✅ 1. 메시지 먼저 삭제
+        chatMessageRepository.deleteByChatRoomId(roomId);
+
+        // ✅ 2. 참가자 삭제
+        chatRoomParticipantRepository.deleteByChatRoomId(roomId);
+
+        // ✅ 3. 채팅방 삭제
         chatRoomRepository.deleteById(roomId);
     }
+
 
 }


### PR DESCRIPTION
채팅방 삭제하는 도중 채팅 내역, 채팅 참가자 정보를 외래키로 가져오고 있어서 채팅방 삭제에 문제가 있었습니다.
먼저 채팅 내역, 채팅 참가자 정보를 삭제하고 채팅방 삭제하는 로직을 추가하였습니다.